### PR TITLE
main: implement a mock to enter the DANGER ZONE

### DIFF
--- a/dynamo_mock.go
+++ b/dynamo_mock.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
+)
+
+type DynamoDBMock struct {
+	dynamodbiface.DynamoDBAPI
+	maxHeartbeats uint64
+	heartbeats map[string]uint64
+	mu sync.Mutex
+}
+
+func NewDynamoDBMock(iface dynamodbiface.DynamoDBAPI, maxHeartbeats uint64) *DynamoDBMock {
+	return &DynamoDBMock{
+		DynamoDBAPI: iface,
+		maxHeartbeats: maxHeartbeats,
+		heartbeats: make(map[string]uint64),
+	}
+}
+
+func (ddb *DynamoDBMock) UpdateItemWithContext(ctx aws.Context, input *dynamodb.UpdateItemInput, options ...request.Option) (*dynamodb.UpdateItemOutput, error) {
+	if *input.ExpressionAttributeNames["#3"] == "leaseDuration" {
+		owner := *input.ExpressionAttributeValues[":1"].S
+		ddb.mu.Lock()
+		ddb.heartbeats[owner] += 1
+		hb := ddb.heartbeats[owner]
+		ddb.mu.Unlock()
+
+		if hb > ddb.maxHeartbeats {
+			fmt.Printf("[%s]: stopped heartbeat\n", owner)
+			return nil, errors.New("disconnected from AWS")
+		} else {
+			fmt.Printf("[%s]: %d\n", owner, hb)
+		}
+	}
+
+	return ddb.DynamoDBAPI.UpdateItemWithContext(ctx, input, options...)
+}


### PR DESCRIPTION
So, how do we ensure that lock acquisition is linearizable even when our process stalls and we stop heartbeating our lock server?

This seems like a very hard thing to do! Simulating a total stall in the Go process is tricky (I have some ideas on how to do that if that's the road we feel we need to go), but for now, here's an alternative: we can hijack the heartbeat path in the DynamoDB client to prevent heartbeats from reaching the server after a configurable amount of time. That's straigthforward! From the lock server's point of view, it looks just like a client stall, so follow-up requests from other threads are going to eventually overtake the lock.

I am still not sure at all of how do we need to update our Porcupine model/sequential specification so it takes into account stalls. I think the problem is compounded by the fact that right now our concurrent execution trace is basically instant (we're locking and unlocking in microseconds), so the heartbeats never make it to the server in the first place. I think we're going to proportionally slow down the whole execution trace in order to model heartbeat stalls.

This is a very interesting problem by the way! Let me know if you'd like to pair on this for a bit.